### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Toner for Tilemill
 ==================
 
-#####NOTE: This repo is for an obsolete version of Toner. For the up-to-date repo, please go to: http://github.com/stamen/toner-carto
+##### NOTE: This repo is for an obsolete version of Toner. For the up-to-date repo, please go to: http://github.com/stamen/toner-carto
 
 ![Toner for Tilemill screenshot](https://raw.github.com/aaronlidman/Toner-for-Tilemill/master/preview.png)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
